### PR TITLE
Align MIME validation across client and server

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -11,13 +11,85 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['file'])) {
     $uploadFilePath = $uploadDir . $uniqueFilename;
 
     // File restrictions
-    $allowedTypes = ['image/jpeg', 'image/png', 'application/pdf', 'text/plain'];
+    $allowedFileTypes = [
+        'jpg' => [
+            'label' => 'JPG/JPEG',
+            'mime' => ['image/jpeg', 'image/pjpeg', 'image/jpg'],
+        ],
+        'jpeg' => [
+            'label' => 'JPG/JPEG',
+            'mime' => ['image/jpeg', 'image/pjpeg', 'image/jpg'],
+        ],
+        'png' => [
+            'label' => 'PNG',
+            'mime' => ['image/png'],
+        ],
+        'pdf' => [
+            'label' => 'PDF',
+            'mime' => ['application/pdf'],
+        ],
+        'txt' => [
+            'label' => 'TXT',
+            'mime' => ['text/plain'],
+        ],
+        'mp4' => [
+            'label' => 'MP4',
+            'mime' => ['video/mp4'],
+        ],
+        'mp3' => [
+            'label' => 'MP3',
+            'mime' => ['audio/mpeg', 'audio/mp3'],
+        ],
+        'zip' => [
+            'label' => 'ZIP',
+            'mime' => ['application/zip', 'application/x-zip-compressed', 'multipart/x-zip'],
+        ],
+        'rar' => [
+            'label' => 'RAR',
+            'mime' => ['application/x-rar-compressed', 'application/vnd.rar'],
+        ],
+    ];
+    $allowedTypeLabels = implode(', ', array_unique(array_map(static function ($info) {
+        return $info['label'];
+    }, $allowedFileTypes)));
+    $genericBrowserMimes = ['application/octet-stream'];
     $maxSizeInBytes = 5 * 1024 * 1024; // 5 MB
 
-    if (!in_array($file['type'], $allowedTypes)) {
+    $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+    if (!isset($allowedFileTypes[$extension])) {
         echo json_encode([
             'status' => 'error',
-            'message' => 'Invalid file type. Allowed types: JPG, PNG, PDF, TXT.'
+            'message' => 'Invalid file type. Allowed types: ' . $allowedTypeLabels . '.',
+        ]);
+        exit;
+    }
+
+    $allowedMimesForExtension = $allowedFileTypes[$extension]['mime'];
+    $browserProvidedMime = isset($file['type']) ? $file['type'] : '';
+
+    if ($browserProvidedMime !== '' && !in_array($browserProvidedMime, $genericBrowserMimes, true) && !in_array($browserProvidedMime, $allowedMimesForExtension, true)) {
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Invalid file type. Allowed types: ' . $allowedTypeLabels . '.',
+        ]);
+        exit;
+    }
+
+    $detectedMimeType = false;
+    if (class_exists('finfo')) {
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        if ($finfo) {
+            $detectedMimeType = $finfo->file($file['tmp_name']);
+        }
+    } elseif (function_exists('mime_content_type')) {
+        $detectedMimeType = mime_content_type($file['tmp_name']);
+    }
+
+    if ($detectedMimeType && !in_array($detectedMimeType, $genericBrowserMimes, true) && !in_array($detectedMimeType, $allowedMimesForExtension, true)) {
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Invalid file type. Allowed types: ' . $allowedTypeLabels . '.',
         ]);
         exit;
     }


### PR DESCRIPTION
## Summary
- expand the shared client-side MIME/extension map and align the file input accept attribute with the supported formats
- centralize front-end file validation so drag-and-drop and picker uploads enforce the same rules before uploading
- mirror the MIME/extension list on the server and add finfo-based checks to keep validation in sync

## Testing
- php -l index.php
- php -l upload.php

------
https://chatgpt.com/codex/tasks/task_e_68c9e4dae190832faad85c628bdba78a