### PR TITLE
Build download URL based on current deployment

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -32,7 +32,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['file'])) {
 
     if ($file['error'] === UPLOAD_ERR_OK) {
         if (move_uploaded_file($file['tmp_name'], $uploadFilePath)) {
-            $downloadUrl = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . '/sandbox/download.php?file=' . urlencode($uniqueFilename);
+            $scheme = !empty($_SERVER['REQUEST_SCHEME'])
+                ? $_SERVER['REQUEST_SCHEME']
+                : (!empty($_SERVER['HTTPS']) ? 'https' : 'http');
+            $host = $_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? 'localhost');
+            $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
+            $scriptDir = str_replace('\\', '/', dirname($scriptName));
+            if ($scriptDir === '/' || $scriptDir === '\\' || $scriptDir === '.') {
+                $scriptDir = '';
+            }
+            $scriptDir = rtrim($scriptDir, '/');
+            $downloadPath = ($scriptDir !== '' ? $scriptDir : '') . '/download.php';
+            $downloadUrl = $scheme . '://' . $host . $downloadPath . '?file=' . urlencode($uniqueFilename);
             echo json_encode([
                 'status' => 'success',
                 'message' => 'File uploaded successfully!',


### PR DESCRIPTION
## Summary
- build the download URL using the current script directory instead of a hard-coded path
- add REQUEST_SCHEME fallback that inspects HTTPS to determine the scheme
- keep returning the normalized download URL in the upload response

## Testing
- php -l upload.php

------
https://chatgpt.com/codex/tasks/task_e_68c9e4bd36e4832f9289d635ca9bf41f