### PR TITLE
Persist upload mapping after successful uploads

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -32,11 +32,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['file'])) {
 
     if ($file['error'] === UPLOAD_ERR_OK) {
         if (move_uploaded_file($file['tmp_name'], $uploadFilePath)) {
+            $mappingFile = 'file_mapping.json';
+            $mappings = [];
+
+            if (file_exists($mappingFile)) {
+                $mappingContents = file_get_contents($mappingFile);
+                if ($mappingContents !== false && trim($mappingContents) !== '') {
+                    $decodedMappings = json_decode($mappingContents, true);
+                    if (is_array($decodedMappings)) {
+                        $mappings = $decodedMappings;
+                    }
+                }
+            }
+
+            $mappings[$uniqueFilename] = $uploadFilePath;
+            $encodedMappings = json_encode($mappings, JSON_PRETTY_PRINT);
+
+            if ($encodedMappings === false || file_put_contents($mappingFile, $encodedMappings, LOCK_EX) === false) {
+                unlink($uploadFilePath);
+                echo json_encode([
+                    'status' => 'error',
+                    'message' => 'Failed to update file mapping.'
+                ]);
+                exit;
+            }
+
             $downloadUrl = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . '/sandbox/download.php?file=' . urlencode($uniqueFilename);
             echo json_encode([
                 'status' => 'success',
                 'message' => 'File uploaded successfully!',
-                'download_url' => $downloadUrl
+                'download_url' => $downloadUrl,
+                'file_id' => $uniqueFilename
             ]);
         } else {
             echo json_encode([


### PR DESCRIPTION
## Summary
- load the existing file mapping after uploading a file and treat missing or empty data as empty
- append the new upload mapping and persist it with exclusive locking
- return the file identifier in the upload response for download resolution

## Testing
- php -l upload.php

------
https://chatgpt.com/codex/tasks/task_e_68c9e4bc42c4832f86d68e0d243b82e1